### PR TITLE
fix(deploy): Add database connectivity verification and improve health checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -359,6 +359,17 @@ jobs:
             docker compose -p livrolog -f docker-compose.prod.yml pull
             docker compose -p livrolog -f docker-compose.prod.yml up -d --remove-orphans --force-recreate
 
+            # Verify connectivity from API container to host services
+            echo "🔍 Verifying API container connectivity..."
+            API_CID=$(docker compose -p livrolog ps -q api)
+            if [ -n "$API_CID" ]; then
+              echo "API Container ID: $API_CID"
+              echo "Testing host.docker.internal resolution:"
+              docker exec "$API_CID" getent hosts host.docker.internal || true
+              echo "Testing database connectivity:"
+              docker exec "$API_CID" timeout 5 bash -c 'cat < /dev/null > /dev/tcp/host.docker.internal/3306' && echo "✅ Database port 3306 reachable" || echo "❌ Database port 3306 unreachable"
+            fi
+
             # Wait for health checks with timeout
             echo "⏳ Waiting for services to be healthy (max 180s)..."
             deadline=$((SECONDS+180))

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,7 +43,7 @@ services:
     depends_on:
       - api
     healthcheck:
-      test: ["CMD", "sh", "-c", "curl -fsS http://localhost/healthz && curl -fsS http://127.0.0.1:18081/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost/healthz"]
       interval: 15s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## Summary by Sourcery

Add connectivity checks for API container in the deploy workflow and simplify the production healthcheck endpoint.

CI:
- Add step in deploy pipeline to verify API container can resolve host.docker.internal and reach database port 3306

Deployment:
- Simplify prod Docker Compose healthcheck to only hit the /healthz endpoint