### PR TITLE
fix(deploy): Remove DB wait from entrypoint and add MySQL config scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -387,6 +387,16 @@ jobs:
               
               if [ $SECONDS -ge $deadline ]; then
                 echo "❌ Health checks timed out, performing rollback..."
+                
+                echo "=== Host DB socket/listeners ==="
+                sudo ss -ltnp | (grep :3306 || true) || true
+                echo "=== UFW status ==="
+                sudo ufw status || true
+
+                echo "=== API->DB TCP test ==="
+                API_CID=$(docker compose -p livrolog ps -q api)
+                [ -n "$API_CID" ] && docker exec "$API_CID" bash -lc 'nc -vz host.docker.internal 3306 || (timeout 5 bash -lc "cat </dev/null >/dev/tcp/host.docker.internal/3306")' || true
+                
                 echo "=== Container Status ==="
                 docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
                 echo "=== Web Logs (last 120 lines) ==="

--- a/scripts/configure-mysql-for-docker.sh
+++ b/scripts/configure-mysql-for-docker.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Configure MySQL/MariaDB to accept Docker container connections
+# Run this script on the production server as root or with sudo
+
+set -e
+
+echo "🔧 Configuring MySQL/MariaDB for Docker container access..."
+
+# 1) Detect MySQL/MariaDB installation type
+if [ -d "/opt/bitnami/mariadb" ]; then
+    echo "📍 Detected Bitnami MariaDB installation"
+    MYSQL_TYPE="bitnami"
+    CONFIG_FILE="/opt/bitnami/mariadb/conf/my.cnf"
+    RESTART_CMD="sudo /opt/bitnami/ctlscript.sh restart mariadb"
+elif [ -f "/etc/mysql/mysql.conf.d/mysqld.cnf" ]; then
+    echo "📍 Detected standard MySQL/MariaDB installation (Debian/Ubuntu)"
+    MYSQL_TYPE="standard"
+    CONFIG_FILE="/etc/mysql/mysql.conf.d/mysqld.cnf"
+    RESTART_CMD="sudo systemctl restart mysql || sudo service mysql restart"
+elif [ -f "/etc/mysql/my.cnf" ]; then
+    echo "📍 Detected MySQL/MariaDB with /etc/mysql/my.cnf"
+    MYSQL_TYPE="standard"
+    CONFIG_FILE="/etc/mysql/my.cnf"
+    RESTART_CMD="sudo systemctl restart mysql || sudo service mysql restart"
+else
+    echo "❌ Could not detect MySQL/MariaDB installation"
+    exit 1
+fi
+
+echo "Using config file: $CONFIG_FILE"
+
+# 2) Check current listeners
+echo "🔍 Current MySQL listeners:"
+sudo ss -ltnp | grep :3306 || sudo netstat -plnt | grep :3306 || echo "No MySQL listeners found"
+
+# 3) Configure bind-address and remove skip-networking
+echo "⚙️  Configuring MySQL to listen on 0.0.0.0:3306..."
+
+if [ "$MYSQL_TYPE" = "bitnami" ]; then
+    # Bitnami configuration
+    sudo sed -i 's/^\s*bind-address\s*=.*/bind-address=0.0.0.0/' "$CONFIG_FILE" || true
+    sudo sed -i 's/^\s*skip-networking/# skip-networking/' "$CONFIG_FILE" || true
+    
+    # Add bind-address if not present
+    if ! grep -q "bind-address" "$CONFIG_FILE"; then
+        echo "bind-address=0.0.0.0" | sudo tee -a "$CONFIG_FILE"
+    fi
+else
+    # Standard installation
+    sudo sed -i 's/^\s*bind-address\s*=.*/bind-address = 0.0.0.0/' /etc/mysql/mysql.conf.d/mysqld.cnf || true
+    sudo sed -i 's/^\s*bind-address\s*=.*/bind-address = 0.0.0.0/' /etc/mysql/my.cnf || true
+    sudo sed -i 's/^\s*skip-networking/# skip-networking/' /etc/mysql/mysql.conf.d/mysqld.cnf || true
+    sudo sed -i 's/^\s*skip-networking/# skip-networking/' /etc/mysql/my.cnf || true
+fi
+
+# 4) Configure firewall for Docker bridge network
+echo "🛡️ Configuring UFW firewall for Docker bridge network..."
+sudo ufw allow from 172.17.0.0/16 to any port 3306 proto tcp
+
+# 5) Restart MySQL/MariaDB
+echo "🔄 Restarting MySQL/MariaDB..."
+eval "$RESTART_CMD"
+
+# 6) Wait for service to be ready
+echo "⏳ Waiting for MySQL/MariaDB to start..."
+sleep 3
+
+# 7) Verify configuration
+echo "✅ Verification:"
+echo "MySQL listeners after restart:"
+sudo ss -ltnp | grep :3306 || sudo netstat -plnt | grep :3306 || echo "❌ MySQL not listening on 3306"
+
+echo "UFW rules:"
+sudo ufw status numbered
+
+echo ""
+echo "✅ MySQL/MariaDB configuration completed!"
+echo ""
+echo "🔧 Configuration applied:"
+echo "  • bind-address = 0.0.0.0 (listens on all interfaces)"
+echo "  • skip-networking commented out (allows network connections)"
+echo "  • UFW rule: allow from 172.17.0.0/16 to port 3306"
+echo ""
+echo "🚀 Docker containers can now connect to MySQL/MariaDB!"

--- a/scripts/validate-docker-db-connection.sh
+++ b/scripts/validate-docker-db-connection.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Validate Docker container can connect to host MySQL/MariaDB
+# Run this script on the production server after configuring MySQL
+
+set -e
+
+echo "🧪 Validating Docker container database connectivity..."
+
+# Change to docker directory
+cd /var/www/livrolog/docker
+
+# Set environment variables
+export OWNER=arnonrdp
+export TAG=prod
+
+echo "🐳 Starting API container for connectivity test..."
+docker compose -p livrolog -f docker-compose.prod.yml up -d api
+
+# Wait for container to start
+sleep 5
+
+# Get API container ID
+API_CID=$(docker compose -p livrolog ps -q api)
+
+if [ -z "$API_CID" ]; then
+    echo "❌ API container not found or not started"
+    exit 1
+fi
+
+echo "📍 API Container ID: $API_CID"
+
+# Test 1: Check if host.docker.internal resolves
+echo ""
+echo "🔍 Test 1: DNS resolution of host.docker.internal"
+if docker exec "$API_CID" getent hosts host.docker.internal; then
+    echo "✅ host.docker.internal resolves correctly"
+else
+    echo "❌ host.docker.internal does not resolve"
+    exit 1
+fi
+
+# Test 2: Test TCP connectivity to MySQL port
+echo ""
+echo "🔍 Test 2: TCP connectivity to MySQL port 3306"
+if docker exec "$API_CID" bash -c 'timeout 5 bash -c "cat </dev/null >/dev/tcp/host.docker.internal/3306"' 2>/dev/null; then
+    echo "✅ Database port 3306 is reachable"
+else
+    echo "❌ Database port 3306 is not reachable"
+    echo "Trying with nc (if available):"
+    docker exec "$API_CID" bash -c 'nc -vz host.docker.internal 3306' || true
+    exit 1
+fi
+
+# Test 3: Check container health
+echo ""
+echo "🔍 Test 3: Container health check"
+if docker exec "$API_CID" curl -fsS "http://localhost:8080/health" >/dev/null 2>&1; then
+    echo "✅ API health endpoint responds correctly"
+else
+    echo "❌ API health endpoint not responding"
+    echo "Container logs (last 20 lines):"
+    docker logs --tail=20 "$API_CID"
+fi
+
+# Test 4: Check if Laravel can connect to database (optional)
+echo ""
+echo "🔍 Test 4: Laravel database connectivity (optional)"
+if docker exec "$API_CID" php -r "
+try {
+    \$pdo = new PDO('mysql:host=host.docker.internal;port=3306;dbname=information_schema', 'root', getenv('DB_PASSWORD') ?: '');
+    echo 'Database connection successful' . PHP_EOL;
+} catch (Exception \$e) {
+    echo 'Database connection failed: ' . \$e->getMessage() . PHP_EOL;
+}
+" 2>/dev/null; then
+    echo "✅ Laravel can connect to database"
+else
+    echo "⚠️ Laravel cannot connect to database (check credentials in .env)"
+fi
+
+echo ""
+echo "🧹 Cleaning up test container..."
+docker compose -p livrolog -f docker-compose.prod.yml down || true
+
+echo ""
+echo "✅ Validation completed!"
+echo ""
+echo "📋 Summary:"
+echo "  • host.docker.internal resolves correctly"
+echo "  • TCP port 3306 is reachable from container"
+echo "  • API health endpoint responds"
+echo ""
+echo "🚀 Ready for production deployment!"


### PR DESCRIPTION
## Summary by Sourcery

Streamline the API Docker entrypoint by removing blocking DB wait logic and hardening optimization commands, enrich deployment diagnostics upon health check failures, and introduce scripts to configure and validate MySQL/MariaDB connectivity for Docker containers.

New Features:
- Add a validate-docker-db-connection.sh script to verify Docker container connectivity to MySQL/MariaDB before production deployment
- Add a configure-mysql-for-docker.sh script to configure MySQL/MariaDB for Docker container access

Enhancements:
- Remove database readiness loop from the Docker entrypoint and make Laravel caching and Swagger generation commands non-blocking
- Extend the GitHub Actions deploy workflow to log MySQL socket listeners, UFW status, and API-to-database connectivity when health checks time out

CI:
- Enhance the deployment workflow with additional debugging steps for database connectivity failures