### PR TITLE
fix(deploy): Make auto-repair script POSIX-compatible and eliminate bad substitution error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -236,7 +236,7 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           envs: GHCR_PAT,GITHUB_SHA,GITHUB_REF_NAME,APP_KEY
           script: |
-            set -euo pipefail
+            set -eu
             DOCKER_DIR="/var/www/livrolog/docker"
             OWNER="arnonrdp"
             IMAGE_API="ghcr.io/${OWNER}/livrolog-api"
@@ -255,15 +255,15 @@ jobs:
             
             if [ -n "${APP_KEY:-}" ] && echo "$APP_KEY" | grep -Eq '^base64:.{50,}'; then
               echo "✅ Valid APP_KEY found in GitHub secret, updating .env..."
-              if grep -q '^APP_KEY=' /var/www/livrolog/shared/.env; then
-                sed -i 's/^APP_KEY=.*/APP_KEY='"$APP_KEY"'/' /var/www/livrolog/shared/.env
-                echo "   Updated existing APP_KEY line"
-              else
-                printf '\nAPP_KEY=%s\n' "$APP_KEY" >> /var/www/livrolog/shared/.env
-                echo "   Added new APP_KEY line"
-              fi
+              tmpfile="$(mktemp)"
+              # Remove existing APP_KEY lines
+              grep -v '^APP_KEY=' /var/www/livrolog/shared/.env > "$tmpfile" || true
+              # Add new APP_KEY line (safe from special characters)
+              printf 'APP_KEY=%s\n' "$APP_KEY" >> "$tmpfile"
+              mv "$tmpfile" /var/www/livrolog/shared/.env
+              echo "   Updated .env with new APP_KEY"
             else
-              echo "⚠️ No valid APP_KEY in GitHub secret (${#APP_KEY:-0} chars)"
+              echo "⚠️ No valid APP_KEY in GitHub secret"
             fi
 
             # Pre-checks: verify environment and infrastructure


### PR DESCRIPTION
## Summary by Sourcery

Make the deploy auto-repair script POSIX-compatible and resolve a bad substitution error when updating APP_KEY in the .env file

Bug Fixes:
- Fix bad substitution error by eliminating direct sed replacement and using a temporary file approach

Enhancements:
- Remove the bash-specific pipefail option from the CI deploy script for broader shell compatibility
- Replace sed-based APP_KEY update with a mktemp, grep, and printf sequence to safely handle special characters

CI:
- Update the GitHub Actions deploy job to use POSIX-compliant shell commands