### PR TITLE
fix(deploy): Fix APP_KEY regex validation to accept Laravel's 44-char base64 keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,34 +251,31 @@ jobs:
             echo "🔧 Auto-provisioning .env (APP_KEY)..."
             sudo mkdir -p /var/www/livrolog/shared
             sudo touch /var/www/livrolog/shared/.env
-            sudo chown -R $USER:$USER /var/www/livrolog
+            sudo chown -R "$USER:$USER" /var/www/livrolog
             
-            # Tenta usar APP_KEY de secret, senão gera
-            APP_KEY_CAND=""
-            
-            # 1) Secret do GitHub (se presente e válido)
-            if [ -n "${APP_KEY:-}" ] && echo "$APP_KEY" | grep -Eq '^base64:.{50,}'; then
-              APP_KEY_CAND="$APP_KEY"
-            else
-              echo "⚠️ APP_KEY secret ausente/inválido; gerando automaticamente via Docker..."
-              
-              # 2) Geração via Docker (php:8.3-cli)
-              APP_KEY_CAND="$(docker run --rm php:8.3-cli php -r 'echo "base64:".base64_encode(random_bytes(32)).PHP_EOL;' 2>/dev/null || true)"
-              
-              # 3) Fallback opcional local (se openssl existir), apenas se ainda inválido
-              if ! echo "$APP_KEY_CAND" | grep -Eq '^base64:.{50,}'; then
-                if command -v openssl >/dev/null 2>&1; then
-                  APP_KEY_CAND="$(openssl rand -base64 32 2>/dev/null | awk '{print "base64:"$0}' || true)"
-                fi
+            # Função POSIX para gerar APP_KEY compatível com Laravel (sem depender de imagens externas)
+            gen_app_key() {
+              if command -v head >/dev/null 2>&1 && command -v base64 >/dev/null 2>&1; then
+                head -c 32 /dev/urandom | base64 | tr -d '\n' | awk '{print "base64:" $0}'
+              elif command -v openssl >/dev/null 2>&1; then
+                openssl rand -base64 32 | tr -d '\n' | awk '{print "base64:" $0}'
+              else
+                dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\n' | awk '{print "base64:" $0}'
               fi
+            }
+            
+            # 1) Tenta usar a secret APP_KEY; se ausente/inválida, gera automaticamente
+            APP_KEY_CAND="${APP_KEY:-}"
+            if ! printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{40,}$'; then
+              echo "⚠️ APP_KEY secret ausente/inválido; gerando automaticamente..."
+              APP_KEY_CAND="$(gen_app_key || true)"
             fi
             
-            # Valida novamente
-            if echo "$APP_KEY_CAND" | grep -Eq '^base64:.{50,}'; then
+            # 2) Valida e grava no .env (operação atômica)
+            if printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{40,}$'; then
               tmpfile="$(mktemp)"
-              # Remove qualquer APP_KEY atual
+              # Remove qualquer APP_KEY existente e escreve a nova (seguro p/ caracteres especiais)
               grep -v '^APP_KEY=' /var/www/livrolog/shared/.env > "$tmpfile" || true
-              # Escreve a APP_KEY validada (sem sed; seguro p/ caracteres especiais)
               printf 'APP_KEY=%s\n' "$APP_KEY_CAND" >> "$tmpfile"
               mv "$tmpfile" /var/www/livrolog/shared/.env
               echo "✅ APP_KEY provisionada/atualizada em /var/www/livrolog/shared/.env"
@@ -294,9 +291,9 @@ jobs:
             test -f /var/www/livrolog/shared/.env || { echo "❌ /var/www/livrolog/shared/.env não existe"; exit 1; }
             test -d /var/www/livrolog/shared/storage || { echo "❌ /var/www/livrolog/shared/storage não existe"; exit 1; }
             
-            # Check 2: APP_KEY validation
+            # Validação correta da APP_KEY no .env (44+ chars após base64:)
             echo "Validating APP_KEY in .env..."
-            if ! grep -Eq '^APP_KEY=base64:.{50,}' /var/www/livrolog/shared/.env; then
+            if ! grep -Eq '^APP_KEY=base64:[A-Za-z0-9+/=]{40,}$' /var/www/livrolog/shared/.env; then
               echo "❌ APP_KEY inválido/ausente em /var/www/livrolog/shared/.env"
               echo ""
               echo "🔧 Para corrigir:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,13 +266,13 @@ jobs:
             
             # 1) Tenta usar a secret APP_KEY; se ausente/inválida, gera automaticamente
             APP_KEY_CAND="${APP_KEY:-}"
-            if ! printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{40,}$'; then
+            if ! printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{44}$'; then
               echo "⚠️ APP_KEY secret ausente/inválido; gerando automaticamente..."
               APP_KEY_CAND="$(gen_app_key || true)"
             fi
             
             # 2) Valida e grava no .env (operação atômica)
-            if printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{40,}$'; then
+            if printf '%s' "$APP_KEY_CAND" | grep -Eq '^base64:[A-Za-z0-9+/=]{44}$'; then
               tmpfile="$(mktemp)"
               # Remove qualquer APP_KEY existente e escreve a nova (seguro p/ caracteres especiais)
               grep -v '^APP_KEY=' /var/www/livrolog/shared/.env > "$tmpfile" || true
@@ -293,7 +293,7 @@ jobs:
             
             # Validação correta da APP_KEY no .env (44+ chars após base64:)
             echo "Validating APP_KEY in .env..."
-            if ! grep -Eq '^APP_KEY=base64:[A-Za-z0-9+/=]{40,}$' /var/www/livrolog/shared/.env; then
+            if ! grep -Eq '^APP_KEY=base64:[A-Za-z0-9+/=]{44}$' /var/www/livrolog/shared/.env; then
               echo "❌ APP_KEY inválido/ausente em /var/www/livrolog/shared/.env"
               echo ""
               echo "🔧 Para corrigir:"


### PR DESCRIPTION
## Summary by Sourcery

Refine the deploy workflow to correctly accept and generate Laravel’s 44-character base64 APP_KEY and securely provision it in the shared .env

Bug Fixes:
- correct the APP_KEY validation regex to match base64:[A-Za-z0-9+/=]{40,} keys

Enhancements:
- introduce a POSIX gen_app_key function to generate valid APP_KEY without external Docker
- simplify provisioning logic to use the provided secret or gen_app_key and perform an atomic .env update
- quote the chown command to handle user:group strings safely