### PR TITLE
fix: use MariaDB built-in healthcheck script in Docker Compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - /var/www/livrolog/shared/db:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysql --silent --connect-timeout=5 -u root -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1' >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## Summary
Fix MariaDB healthcheck in Docker Compose production configuration to resolve canary deployment failures.

## Problem
The previous custom healthcheck command was failing because it couldn't properly access the `MYSQL_ROOT_PASSWORD` variable, causing "Access denied" errors repeatedly and making the MariaDB container unhealthy.

This caused the GitHub Actions canary deployment workflow to fail.

## Solution
Replace the custom healthcheck command with MariaDB's built-in `healthcheck.sh` script, which:
- Properly handles authentication
- Checks database connectivity
- Verifies InnoDB initialization
- Is maintained by the MariaDB image maintainers

## Changes
- Updated `docker-compose.prod.yml` healthcheck for MariaDB service
- Changed from: `mysql --silent --connect-timeout=5 -u root -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'`
- Changed to: `healthcheck.sh --connect --innodb_initialized`

## Test Plan
- [x] Verified healthcheck.sh is available in mariadb:10.11-jammy image
- [x] Syntax validated
- [ ] GitHub Actions canary deployment should pass
- [ ] MariaDB container should become healthy within start_period

## Impact
- No impact on running production containers (they don't use docker-compose.prod.yml)
- Only affects new deployments via GitHub Actions
- No data loss or configuration changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the custom MariaDB healthcheck command in docker-compose.prod.yml with the built-in healthcheck.sh script to resolve authentication failures and ensure container health for canary deployments

Bug Fixes:
- Switch MariaDB healthcheck to use the official healthcheck.sh script to avoid MySQL root access errors

Deployment:
- Ensure new deployments via GitHub Actions use the updated healthcheck configuration

Tests:
- Verify healthcheck.sh availability and syntax in the mariadb:10.11-jammy image