### PR TITLE
feat(seo): render readers' reviews and link books by the same author

### DIFF
--- a/api/app/Http/Middleware/SocialMediaCrawlerMiddleware.php
+++ b/api/app/Http/Middleware/SocialMediaCrawlerMiddleware.php
@@ -290,6 +290,96 @@ class SocialMediaCrawlerMiddleware
     }
 
     /**
+     * Readers' own reviews, rendered on the page.
+     *
+     * This is not decoration. Google requires that a rating marked up with AggregateRating be
+     * visible to the user on that page, so this is what makes the JSON-LD rating legitimate.
+     * It is also what separates the page from a thin affiliate page: without it the content is
+     * a publisher blurb plus a buy button, which the spam policy names explicitly.
+     */
+    private function renderBookReviews(Book $book, bool $isPt, callable $e): string
+    {
+        $count = $book->reviews_count;
+
+        if ($count < 1) {
+            return '';
+        }
+
+        $average = round((float) $book->average_rating, 1);
+        $heading = $isPt ? 'Avaliações dos leitores' : 'Reader reviews';
+        $summary = $isPt
+            ? "Nota média {$average} de 5, com {$count} ".($count === 1 ? 'avaliação' : 'avaliações')
+            : "Rated {$average} out of 5 by {$count} ".($count === 1 ? 'reader' : 'readers');
+
+        $items = '';
+        foreach ($book->publicReviews()->with('user')->latest()->limit(5)->get() as $review) {
+            $body = trim(strip_tags((string) $review->content));
+            if ($body === '') {
+                continue;
+            }
+            if (mb_strlen($body) > 400) {
+                $body = mb_substr($body, 0, 397).'...';
+            }
+
+            $author = trim(strip_tags((string) ($review->user->display_name ?? $review->user->username ?? '')));
+            $title = trim(strip_tags((string) $review->title));
+
+            $items .= '<li>'
+                .($title !== '' ? '<strong>'.$e($title).'</strong> ' : '')
+                .'<span>'.$e(($isPt ? 'Nota ' : 'Rated ').$review->rating.'/5').'</span> '
+                .($author !== '' ? '<cite>'.$e($author).'</cite> ' : '')
+                .'<p>'.$e($body).'</p>'
+                .'</li>';
+        }
+
+        return '<h2>'.$e($heading).'</h2><p class="rating-summary">'.$e($summary).'</p>'
+            .($items !== '' ? '<ul class="reviews">'.$items.'</ul>' : '');
+    }
+
+    /**
+     * Links to other books by the same author.
+     *
+     * Every book page was a dead end in the link graph: the only anchor in the body pointed at
+     * the page itself. books.authors is a plain string column, so this is a LIKE away — the
+     * Author model exists but nothing in the codebase ever writes to it.
+     */
+    private function renderSameAuthorLinks(Book $book, string $author, bool $isPt, callable $e): string
+    {
+        if ($author === '') {
+            return '';
+        }
+
+        $primary = trim(explode(',', $author)[0]);
+        if ($primary === '') {
+            return '';
+        }
+
+        $frontend = rtrim(config('app.frontend_url'), '/');
+
+        $others = Book::query()
+            ->select('id', 'title')
+            ->where('id', '!=', $book->id)
+            ->where('authors', 'like', '%'.$primary.'%')
+            ->orderBy('title')
+            ->limit(10)
+            ->get();
+
+        if ($others->isEmpty()) {
+            return '';
+        }
+
+        $items = '';
+        foreach ($others as $other) {
+            $href = $e($frontend.'/books/'.rawurlencode($other->id));
+            $items .= '<li><a href="'.$href.'">'.$e(trim(strip_tags((string) $other->title))).'</a></li>';
+        }
+
+        $heading = $isPt ? "Outros livros de {$primary}" : "More by {$primary}";
+
+        return '<h2>'.$e($heading).'</h2><ul class="also-by">'.$items.'</ul>';
+    }
+
+    /**
      * schema.org/Book as JSON-LD, which is what search engines read for rich results.
      *
      * Deliberately carries no aggregateRating. The ratings on hand are amazon_rating and
@@ -322,6 +412,21 @@ class SocialMediaCrawlerMiddleware
 
         if ($book->publisher) {
             $data['publisher'] = ['@type' => 'Organization', 'name' => $book->publisher];
+        }
+
+        // LivroLog's own readers' ratings, and only these. They are rendered on the page by
+        // renderBookReviews(), which is Google's condition for marking them up. Emitted only
+        // when reviews exist, so a book nobody rated never carries a zero-star node.
+        $reviewsCount = $book->reviews_count;
+
+        if ($reviewsCount > 0) {
+            $data['aggregateRating'] = [
+                '@type' => 'AggregateRating',
+                'ratingValue' => round((float) $book->average_rating, 1),
+                'reviewCount' => $reviewsCount,
+                'bestRating' => 5,
+                'worstRating' => 1,
+            ];
         }
 
         // JSON_HEX_TAG keeps a "</script>" inside any field from closing the block early
@@ -371,6 +476,20 @@ class SocialMediaCrawlerMiddleware
 
         $cta = $e($isPt ? 'Ver no LivroLog' : 'See it on LivroLog');
         $safeCanonical = $e($canonical);
+
+        $categories = '';
+        foreach ((array) $book->categories as $category) {
+            $category = trim(strip_tags((string) $category));
+            if ($category !== '') {
+                $categories .= '<li>'.$e($category).'</li>';
+            }
+        }
+        $categories = $categories !== ''
+            ? '<h2>'.$e($isPt ? 'Assuntos' : 'Subjects').'</h2><ul class="categories">'.$categories.'</ul>'
+            : '';
+
+        $reviews = $this->renderBookReviews($book, $isPt, $e);
+        $alsoBy = $this->renderSameAuthorLinks($book, $author, $isPt, $e);
         $jsonLd = $this->bookJsonLd($book, $fullTitle, $author, $canonical, $cover);
 
         return <<<BODY
@@ -381,6 +500,9 @@ class SocialMediaCrawlerMiddleware
         {$byline}
         {$facts}
         {$description}
+        {$categories}
+        {$reviews}
+        {$alsoBy}
         <p><a href="{$safeCanonical}">{$cta}</a></p>
     </article>
 BODY;

--- a/api/tests/Feature/SeoCrawlerTest.php
+++ b/api/tests/Feature/SeoCrawlerTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature;
 
 use App\Models\Book;
+use App\Models\Review;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -142,9 +144,79 @@ class SeoCrawlerTest extends TestCase
         $this->assertSame('Arqueiro', $data['publisher']['name']);
 
         // Google: "Don't aggregate reviews or ratings from other websites." The Amazon rating is
-        // on this record and must never reach the markup.
+        // on this record, the book has no reviews of our own, so no rating may appear at all.
         $this->assertArrayNotHasKey('aggregateRating', $data);
         $this->assertStringNotContainsString('4.8', $matches[1]);
+        $this->assertStringNotContainsString('12000', $matches[1]);
+    }
+
+    public function test_own_reviews_are_rendered_and_are_the_only_rating_marked_up(): void
+    {
+        $book = Book::factory()->create([
+            'authors' => 'Clarice Lispector',
+            'amazon_rating' => 4.8,
+            'amazon_rating_count' => 12000,
+        ]);
+
+        $reviewers = User::factory()->count(2)->create();
+        Review::factory()->create([
+            'book_id' => $book->id, 'user_id' => $reviewers[0]->id,
+            'rating' => 5, 'content' => 'Prosa que reorganiza o pensamento.',
+            'visibility_level' => 'public',
+        ]);
+        Review::factory()->create([
+            'book_id' => $book->id, 'user_id' => $reviewers[1]->id,
+            'rating' => 4, 'content' => 'Difícil no começo, recompensador depois.',
+            'visibility_level' => 'public',
+        ]);
+
+        $html = $this->withHeader('User-Agent', self::GOOGLEBOT)
+            ->get('/books/'.$book->id)
+            ->getContent();
+
+        // visible on the page — Google's precondition for marking a rating up at all
+        $this->assertStringContainsString('Prosa que reorganiza o pensamento.', $html);
+        $this->assertStringContainsString('4.5', $html);
+
+        preg_match('#<script type="application/ld\+json">(.*?)</script>#s', $html, $matches);
+        $data = json_decode($matches[1], true);
+
+        $this->assertSame(4.5, $data['aggregateRating']['ratingValue']);
+        $this->assertSame(2, $data['aggregateRating']['reviewCount']);
+
+        // still never Amazon's numbers
+        $this->assertStringNotContainsString('12000', $matches[1]);
+    }
+
+    public function test_private_reviews_are_not_rendered_or_counted(): void
+    {
+        $book = Book::factory()->create();
+        Review::factory()->create([
+            'book_id' => $book->id, 'user_id' => User::factory()->create()->id,
+            'rating' => 1, 'content' => 'Anotação particular que não deve vazar.',
+            'visibility_level' => 'private',
+        ]);
+
+        $html = $this->withHeader('User-Agent', self::GOOGLEBOT)
+            ->get('/books/'.$book->id)
+            ->getContent();
+
+        $this->assertStringNotContainsString('Anotação particular', $html);
+        $this->assertStringNotContainsString('aggregateRating', $html);
+    }
+
+    public function test_book_links_to_other_books_by_the_same_author(): void
+    {
+        $book = Book::factory()->create(['title' => 'A Hora da Estrela', 'authors' => 'Clarice Lispector']);
+        $sibling = Book::factory()->create(['title' => 'Água Viva', 'authors' => 'Clarice Lispector']);
+        $unrelated = Book::factory()->create(['title' => 'Dom Casmurro', 'authors' => 'Machado de Assis']);
+
+        $html = $this->withHeader('User-Agent', self::GOOGLEBOT)
+            ->get('/books/'.$book->id)
+            ->getContent();
+
+        $this->assertStringContainsString('/books/'.$sibling->id, $html);
+        $this->assertStringNotContainsString('/books/'.$unrelated->id, $html);
     }
 
     public function test_book_title_is_escaped_in_the_rendered_body(): void


### PR DESCRIPTION
Sequência dos dois itens que ficaram mapeados no #1226 e não foram feitos lá.

## Por quê

Depois do #1226 a página de livro é indexável e tem conteúdo — mas o conteúdo é a sinopse do Google Books mais um botão de compra. A política de spam do Google nomeia exatamente isso:

> "publishing content with product affiliate links where the product descriptions and reviews are copied directly from the original merchant without any original content or added value"

E cada página era um beco sem saída: o único `<a>` do corpo apontava para ela mesma. 653 ilhas alcançáveis só pelo sitemap.

## O que muda

**Reviews, assuntos e resumo de nota no corpo renderizado.** É o conteúdo original que faltava — o que os seus leitores escreveram, que não existe em nenhum outro site.

**`aggregateRating` no JSON-LD**, construído estritamente das reviews públicas do LivroLog, e só quando existem. Livro sem avaliação não ganha nó de nota em vez de ganhar zero estrelas. O Google exige que a nota marcada esteja visível na página, e é por isso que isto dependia das reviews renderizarem — as duas metades são um commit só.

`amazon_rating` e `amazon_rating_count` seguem fora, como antes: *"Don't aggregate reviews or ratings from other websites."* Há testes para as duas metades — que a nossa média chega ao markup, e que os números da Amazon nunca chegam, mesmo num registro que os tem.

**Links "outros livros do autor".** Dá ao catálogo um grafo interno que o crawler percorre. `books.authors` é coluna string, então é um `LIKE` com limite — o model `Author` existe mas nada no código escreve nele.

## Privacidade

Um teste fixa que review privada nunca chega à página renderizada nem à nota. O render do crawler contorna os API Resources que normalmente garantem isso, então precisou de guarda própria.

## Verificação

377 testes, `pint` limpo. Confirmado contra dados semeados no render ao vivo: assuntos, lista de reviews, resumo de nota, `aggregateRating` de 3.4 vindo de 5 reviews, e links por autor.

```
$ curl -s -A "Googlebot/2.1" localhost:8000/books/B-Y43G-FLBA
  <h2>Assuntos</h2>  <h2>Avaliações dos leitores</h2>
  aggregateRating: {ratingValue: 3.4, reviewCount: 5, bestRating: 5, worstRating: 1}
  <h2>Outros livros de Peter Thiel</h2> → /books/B-TEST-SIB
```

## Nota de escala

`renderSameAuthorLinks` faz `LIKE '%autor%'` sem índice em `authors`. Com centenas de livros é irrelevante; se o catálogo crescer muito, o caminho é indexar a coluna ou finalmente popular o model `Author`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM3bUo411kUuZxq5r7x5Nr